### PR TITLE
Use GHCR_TOKEN secret for package push auth

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Extract metadata
       id: meta


### PR DESCRIPTION
The automatic GITHUB_TOKEN doesn't always have proper permissions for GHCR package operations. Using a dedicated PAT secret instead.